### PR TITLE
Update ajax_nav.js

### DIFF
--- a/js/ajax_nav.js
+++ b/js/ajax_nav.js
@@ -187,7 +187,7 @@ const ajaxRequest = new (function () {
 	oCover.appendChild(oLoadingImg);
 	oLoadingBox.appendChild(oCover);
 
-	onpopstate = function (oEvent) {
+	window.onpopstate = function (oEvent) {
 		bUpdateURL = false;
 		oPageInfo.title = oEvent.state.title;
 		oPageInfo.url = oEvent.state.url;


### PR DESCRIPTION
I see firefox picks up 
`onpopstate = function (oEvent) {
        bUpdateURL = false;
        oPageInfo.title = oEvent.state.title;
        oPageInfo.url = oEvent.state.url;
        getPage();
    };`

but chrome does not. Adding the     

`window.onpopstate`

gets it to work in chrome, not sure if this is correct or not.
